### PR TITLE
Use real fractions, fix 1/3 -> 2/3

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,18 +173,18 @@
           <div class="two columns">two</div>
         </div>
         <div class="row">
-          <div class="one-third column">1/3</div>
-          <div class="two-thirds column">1/3</div>
+          <div class="one-third column">⅓</div>
+          <div class="two-thirds column">⅔</div>
         </div>
         <div class="row">
-          <div class="one-half column">1/2</div>
-          <div class="one-half column">1/2</div>
+          <div class="one-half column">½</div>
+          <div class="one-half column">½</div>
         </div>
         <div class="row">
-          <div class="one-quarter column">1/4</div>
-          <div class="one-quarter columns">1/4</div>
-          <div class="one-quarter column">1/4</div>
-          <div class="one-quarter column">1/4</div>
+          <div class="one-quarter column">¼</div>
+          <div class="one-quarter columns">¼</div>
+          <div class="one-quarter column">¼</div>
+          <div class="one-quarter column">¼</div>
         </div>
       </div>
 
@@ -206,12 +206,12 @@
 
 
   <div class="row">
-    <div class="one-third column">1/3</div>
-    <div class="two-thirds column">2/3</div>
+    <div class="one-third column">⅓</div>
+    <div class="two-thirds column">⅔</div>
   </div>
   <div class="row">
-    <div class="one-half column">1/2</div>
-    <div class="one-half column">1/2</div>
+    <div class="one-half column">½</div>
+    <div class="one-half column">½</div>
   </div>
 
 </div>


### PR DESCRIPTION
`two-thirds` was incorrectly labeled 1/3.
This PR also introduces unicode fractions ½ ⅔. 
